### PR TITLE
less hardcoded product ids

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -41,18 +41,24 @@ class Websocket {
 
 		this.historic_callback = (err, response, data) => {
 			if (err) {
-				// console.error(err);
+				log.error(process.pid, 'callbackHistoricRates error', err);
 			}
 
 			var try_again = false;
 			if (response) {
-				// console.log(process.pid, 'callbackHistoricRates response: '+ response.request.path);
-				if (response.request.path.includes('BTC-USD')) {
-					var product_id = 'BTC-USD'
-				} else if (response.request.path.includes('ETH-USD')) {
-					var product_id = 'ETH-USD'
-				} else if (response.request.path.includes('LTC-USD')) {
-					var product_id = 'LTC-USD'
+				log.debug(process.pid, 'callbackHistoricRates response path: ' + response.request.path);
+
+				var product_id;
+				this.product_ids.some(function(search_id) {
+					if (response.request.path.indexOf(search_id) !== -1) {
+						product_id = search_id;
+						return true;
+					}
+				});
+
+				if (!product_id) {
+					log.error(process.pid, 'callbackHistoricRates unable to parse product from path: ' + response.request.path);
+					return;
 				}
 
 				try {
@@ -61,7 +67,7 @@ class Websocket {
 						this.trades[product_id].push(parseFloat(i[4]));
 					});
 				} catch (e) {
-					// console.log(e);
+					log.error(process.pid, 'callbackHistoricRates exception', e);
 					try_again = true;
 				}
 
@@ -108,13 +114,13 @@ class Websocket {
 
 			if (!(this.auth.secret && this.auth.key && this.auth.passphrase)) {
 				// UNAUTHENTICATED
-				log.info('Websocket: Connecting UNAUTHENTICATED');
-				this.websocket = new Gdax.WebsocketClient(['BTC-USD', 'ETH-USD', 'LTC-USD'], websocket_url);
+				log.info('Websocket: Connecting UNAUTHENTICATED', this.product_ids);
+				this.websocket = new Gdax.WebsocketClient(this.product_ids, websocket_url);
 				this.gdax = new Gdax.PublicClient(api_url);
 			} else {
 				// AUTHENTICATED
-				log.info('Websocket: Connecting AUTHENTICATED');
-				this.websocket = new Gdax.WebsocketClient(['BTC-USD', 'ETH-USD', 'LTC-USD'], websocket_url, this.auth);
+				log.info('Websocket: Connecting AUTHENTICATED', this.product_ids);
+				this.websocket = new Gdax.WebsocketClient(this.product_ids, websocket_url, this.auth);
 				this.gdax = new Gdax.AuthenticatedClient(this.auth.key, this.auth.secret, this.auth.passphrase, api_url=api_url);
 
 				this.authenticated = true;


### PR DESCRIPTION
* Sending only the enabled product ids in config to `WebsocketClient`
* Parsing product id from `response.request.path`

This is meant to help support other product ids without code changes. I'm thinking about using ETH-BTC/LTC-BTC. Plus this could help EUR/GBP traders.